### PR TITLE
[Feat] Main페이지에서 이번주 주제 '자세히보기' 클릭 시 쿼리 갖고 detail-list로 이동

### DIFF
--- a/app/_components/detail-list/DetailList.tsx
+++ b/app/_components/detail-list/DetailList.tsx
@@ -30,7 +30,6 @@ const DetailList = () => {
     if (isDataLoaded) {
       const queryParams = new URLSearchParams(window.location.search);
       const paramCheck = queryParams.has("onlyWeeklyTopic");
-      console.log("확인확인", paramCheck);
       if (paramCheck) {
         handleWeeklyTopicClick();
       }

--- a/app/_components/detail-list/DetailList.tsx
+++ b/app/_components/detail-list/DetailList.tsx
@@ -32,7 +32,7 @@ const DetailList = () => {
       const paramCheck = queryParams.has("onlyWeeklyTopic");
       console.log("확인확인", paramCheck);
       if (paramCheck) {
-        setIsTopicSelected(true);
+        handleWeeklyTopicClick();
       }
     }
   }, [isDataLoaded]);

--- a/app/_components/detail-list/DetailList.tsx
+++ b/app/_components/detail-list/DetailList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import DrawingPosts from "./DrawingPosts";
 import { getAllPost } from "./posts-all-api";
 import { useQuery } from "@tanstack/react-query";
@@ -9,15 +9,33 @@ import { Posts } from "@/app/_types/detail1/posts";
 const DetailList = () => {
   const [isTopicSelected, setIsTopicSelected] = useState(false);
   const [postData, setPostData] = useState<Posts[]>([]);
+  const [isDataLoaded, setIsDataLoaded] = useState(false);
 
   const {
     data,
     isLoading,
     isError,
-  }: { data: any; isLoading: any; isError: any } = useQuery({
-    queryKey: ["post"],
-    queryFn: () => getAllPost(),
-  });
+  }: { data: Posts[] | undefined; isLoading: boolean; isError: any } = useQuery(
+    {
+      queryKey: ["post"],
+      queryFn: async () => {
+        const postData = await getAllPost();
+        setIsDataLoaded(true);
+        return postData;
+      },
+    }
+  );
+
+  useEffect(() => {
+    if (isDataLoaded) {
+      const queryParams = new URLSearchParams(window.location.search);
+      const paramCheck = queryParams.has("onlyWeeklyTopic");
+      console.log("확인확인", paramCheck);
+      if (paramCheck) {
+        setIsTopicSelected(true);
+      }
+    }
+  }, [isDataLoaded]);
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/app/_components/main/WeeklyTheme.tsx
+++ b/app/_components/main/WeeklyTheme.tsx
@@ -1,9 +1,17 @@
+"use client";
+
 import React from "react";
 import { ThemeImageStyle } from "@/app/_styles/imageStyles";
 import theme from "@/app/_constant/theme";
-import { YellowLinkBtn } from "../common/Button";
+import { useRouter } from "next/navigation";
 
 const WeeklyTheme = () => {
+  const router = useRouter();
+
+  const handleOnClick = () => {
+    router.push("/detail-list?onlyWeeklyTopic");
+  };
+
   return (
     <section className="flex flex-col items-center">
       <div className="w-[1000px] mt-10 flex flex-col gap-2">
@@ -14,7 +22,7 @@ const WeeklyTheme = () => {
         </div>
       </div>
       <div className="w-[1000px] flex justify-end mt-2">
-        <YellowLinkBtn href="/" text="자세히 보기" />
+        <button onClick={handleOnClick}>자세히 보기</button>
       </div>
     </section>
   );

--- a/app/_components/main/WeeklyTheme.tsx
+++ b/app/_components/main/WeeklyTheme.tsx
@@ -22,7 +22,12 @@ const WeeklyTheme = () => {
         </div>
       </div>
       <div className="w-[1000px] flex justify-end mt-2">
-        <button onClick={handleOnClick}>자세히 보기</button>
+        <button
+          onClick={handleOnClick}
+          className="bg-YellowDark px-2.5 py-1 rounded-xl hover:bg-YellowPale"
+        >
+          자세히 보기
+        </button>
       </div>
     </section>
   );


### PR DESCRIPTION
 ## 📌 관련 이슈
#16

## Task TODOLIST
- [x] '자세히 보기' 클릭 시 'onlyWeeklyTheme' 문자열 쿼리 갖고 detail-list로 이동
- [x] 이런 식으로 detail-list로 이동한 경우 주소 /detail-list?onlyWeeklyTheme
- [x]  handleWeeklyTopicClick() 실행하여 이번주 주제 게시글만 필터링 출력

## ✨ 개발 내용
상단 바에 있는 '보러가기' 메뉴 클릭하여 detail-list 페이지에 들어왔을 때 데이터 가져오기 및 렌더링 로직은 바뀐 부분 전혀 없습니다.
main페이지에서 자세히 보기 버튼을 클릭하여 들어온 경우 이번주 주제 글만 바로 볼 수 있도록 처리했습니다.
```
  const {
    data,
    isLoading,
    isError,
  }: { data: Posts[] | undefined; isLoading: boolean; isError: any } = useQuery(
    {
      queryKey: ["post"],
      queryFn: async () => {
        const postData = await getAllPost();
        setIsDataLoaded(true);
        return postData;
      },
    }
  );

  useEffect(() => {
    if (isDataLoaded) {
      const queryParams = new URLSearchParams(window.location.search);
      const paramCheck = queryParams.has("onlyWeeklyTopic");
      if (paramCheck) {
        handleWeeklyTopicClick();
      }
    }
  }, [isDataLoaded]);
```

## 📸 스크린샷(선택)
![image](https://github.com/sparta-PaletteGround/sparta-PaletteGround/assets/153061626/874ccd50-9069-4825-b125-e5c2a5d63e05)
