### PR TITLE
[Feat] Main페이지 기능 구현 완료!

### DIFF
--- a/app/_components/main/BestPainter.tsx
+++ b/app/_components/main/BestPainter.tsx
@@ -2,10 +2,10 @@ import Image from "next/image";
 import React from "react";
 import { BestPainterCard } from "@/app/_styles/bestPainterStyles";
 import { Posts } from "@/app/_types/detail1/posts";
-import { getUsers } from "@/app/_api/getUsers";
 import { User } from "@/app/_types/myPageType";
 
 const BestPainter = async ({ data }: { data: Posts[] }) => {
+  /** users 테이블에서 모든 데이터 가져오기 */
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/users`,
     {
@@ -31,6 +31,7 @@ const BestPainter = async ({ data }: { data: Posts[] }) => {
     .sort((a, b) => b.postCount - a.postCount)
     .slice(0, 3);
 
+  /** Top 3 유저의 이메일 그리고 그 이메일에 해당하는 유저 정보 */
   const bestUserEmails = sortedUsers.map((user) => user.email);
   const bestUsersInfo = usersData.filter((user) =>
     bestUserEmails.includes(user.email)

--- a/app/_components/main/BestPainter.tsx
+++ b/app/_components/main/BestPainter.tsx
@@ -36,15 +36,12 @@ const BestPainter = async ({ data }: { data: Posts[] }) => {
     bestUserEmails.includes(user.email)
   );
 
-  console.log("모든 유저", usersData);
-  console.log("TOP3 유저", bestUsersInfo);
-
   return (
     <section className="flex flex-col items-center">
       <div className="w-[1000px] mt-10 flex flex-col gap-2 mb-10">
         <h1 className="text-large font-bold">👍🏼명예의 전당</h1>
         <p className="pl-6">
-          Palette Ground에 가장 많은 그림을 남겨주신 우수회원 Top 3
+          Palette Ground에 가장 많은 그림을 남겨주신 우수회원 Top 3를
           소개합니다👏🏼👏🏼👏🏼
         </p>
         <div className="bg-PurplePale flex gap-2 rounded-xl p-1 justify-center">

--- a/app/_components/main/BestPainter.tsx
+++ b/app/_components/main/BestPainter.tsx
@@ -44,7 +44,8 @@ const BestPainter = async ({ data }: { data: Posts[] }) => {
       <div className="w-[1000px] mt-10 flex flex-col gap-2 mb-10">
         <h1 className="text-large font-bold">👍🏼명예의 전당</h1>
         <p className="pl-6">
-          Palette Ground에 가장 많은 그림을 남겨주신 우수회원 Top 3👏🏼👏🏼👏🏼
+          Palette Ground에 가장 많은 그림을 남겨주신 우수회원 Top 3
+          소개합니다👏🏼👏🏼👏🏼
         </p>
         <div className="bg-PurplePale flex gap-2 rounded-xl p-1 justify-center">
           {bestUsersInfo.map((item) => (

--- a/app/_components/main/BestPainter.tsx
+++ b/app/_components/main/BestPainter.tsx
@@ -1,15 +1,24 @@
 import Image from "next/image";
 import React from "react";
 import { BestPainterCard } from "@/app/_styles/bestPainterStyles";
-import { Newpost } from "@/app/_types/detail1/posts";
+import { Posts } from "@/app/_types/detail1/posts";
 import { getUsers } from "@/app/_api/getUsers";
+import { User } from "@/app/_types/myPageType";
 
-const BestPainter = async ({ data }: { data: Newpost[] }) => {
-  const users = await getUsers();
-  console.log("깨앵", users);
-  /** 게시글을 가장 많이 작성한 유저 3명 뽑아내기 */
+const BestPainter = async ({ data }: { data: Posts[] }) => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/users`,
+    {
+      next: { revalidate: 10 },
+      headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! },
+    }
+  );
+  const usersData: User[] = await response.json();
+
+  /** posts로부터 가장 많이 작성한 유저 3명 뽑아내기 */
   const userCounts: { [email: string]: number } = {};
   data?.forEach((post) => {
+    if (!post.painter_email) return;
     if (post.painter_email in userCounts) {
       userCounts[post.painter_email]++;
     } else {
@@ -22,51 +31,33 @@ const BestPainter = async ({ data }: { data: Newpost[] }) => {
     .sort((a, b) => b.postCount - a.postCount)
     .slice(0, 3);
 
-  console.log("끼잉", sortedUsers);
+  const bestUserEmails = sortedUsers.map((user) => user.email);
+  const bestUsersInfo = usersData.filter((user) =>
+    bestUserEmails.includes(user.email)
+  );
+
+  console.log("모든 유저", usersData);
+  console.log("TOP3 유저", bestUsersInfo);
 
   return (
     <section className="flex flex-col items-center">
       <div className="w-[1000px] mt-10 flex flex-col gap-2 mb-10">
         <h1 className="text-large font-bold">👍🏼명예의 전당</h1>
-        <div className="w-[1000px] bg-PurplePale flex gap-10 rounded-xl p-5 justify-center">
-          {sortedUsers.map((item) => (
+        <p className="pl-6">
+          Palette Ground에 가장 많은 그림을 남겨주신 우수회원 Top 3👏🏼👏🏼👏🏼
+        </p>
+        <div className="bg-PurplePale flex gap-2 rounded-xl p-1 justify-center">
+          {bestUsersInfo.map((item) => (
             <div style={BestPainterCard} key={item.email} className="flex-col">
               <img
-                src="https://cdn-icons-png.flaticon.com/512/848/848006.png"
+                src={item.profile_img}
                 alt="사용자 이미지"
                 width="70"
                 height="70"
               />
-              <p>그림마스터</p>
+              <p>{item.nickname}</p>
             </div>
           ))}
-          <div style={BestPainterCard} className="flex-col">
-            <img
-              src="https://cdn-icons-png.flaticon.com/512/848/848006.png"
-              alt="사용자 이미지"
-              width="70"
-              height="70"
-            />
-            <p>그림마스터</p>
-          </div>
-          <div style={BestPainterCard} className="flex-col">
-            <img
-              src="https://cdn-icons-png.flaticon.com/512/848/848006.png"
-              alt="사용자 이미지"
-              width="70"
-              height="70"
-            />
-            <p>그림마스터</p>
-          </div>
-          <div style={BestPainterCard} className="flex-col">
-            <img
-              src="https://cdn-icons-png.flaticon.com/512/848/848006.png"
-              alt="사용자 이미지"
-              width="70"
-              height="70"
-            />
-            <p>그림마스터</p>
-          </div>
         </div>
       </div>
     </section>

--- a/app/_components/main/Carousel.tsx
+++ b/app/_components/main/Carousel.tsx
@@ -5,6 +5,14 @@ import { SquareImageStyle } from "@/app/_styles/imageStyles";
 import { Posts } from "@/app/_types/detail1/posts";
 
 const Carousel = ({ data }: { data: Posts[] }) => {
+  const settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
+
   return (
     <section className="flex flex-col justify-center items-center bg-gray-100 h-[400px]">
       <div className="flex flex-col gap-2 w-[1000px]">

--- a/app/_components/main/Carousel.tsx
+++ b/app/_components/main/Carousel.tsx
@@ -1,15 +1,42 @@
+"use client";
+
 import Image from "next/image";
 import React from "react";
-import ExampleImg from "@/public/image/example.jpg";
 import { SquareImageStyle } from "@/app/_styles/imageStyles";
 import { Posts } from "@/app/_types/detail1/posts";
+import ExampleImage from "@/public/image/example.jpg";
+
+import Slider from "react-slick";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
 
 const Carousel = ({ data }: { data: Posts[] }) => {
+  // /** lkies로부터 가장 많이 작성한 유저 3명 뽑아내기 */
+  // const userCounts: { [email: string]: number } = {};
+  // data?.forEach((post) => {
+  //   if (!post.painter_email) return;
+  //   if (post.painter_email in userCounts) {
+  //     userCounts[post.painter_email]++;
+  //   } else {
+  //     userCounts[post.painter_email] = 1;
+  //   }
+  // });
+
+  // const sortedUsers = Object.entries(userCounts)
+  //   .map(([email, postCount]) => ({ email, postCount }))
+  //   .sort((a, b) => b.postCount - a.postCount)
+  //   .slice(0, 3);
+
+  // const bestUserEmails = sortedUsers.map((user) => user.email);
+  // const bestUsersInfo = usersData.filter((user) =>
+  //   bestUserEmails.includes(user.email)
+  // );
+
   const settings = {
     dots: true,
     infinite: true,
     speed: 500,
-    slidesToShow: 1,
+    slidesToShow: 3,
     slidesToScroll: 1,
   };
 
@@ -17,11 +44,27 @@ const Carousel = ({ data }: { data: Posts[] }) => {
     <section className="flex flex-col justify-center items-center bg-gray-100 h-[400px]">
       <div className="flex flex-col gap-2 w-[1000px]">
         <h1 className="text-large font-bold">👑베스트 드로잉</h1>
-        <div className="flex justify-center gap-5">
-          <Image src={ExampleImg} alt="유저의 그림" style={SquareImageStyle} />
-          <Image src={ExampleImg} alt="유저의 그림" style={SquareImageStyle} />
-          <Image src={ExampleImg} alt="유저의 그림" style={SquareImageStyle} />
-        </div>
+        <Slider {...settings}>
+          <div>
+            <Image
+              src={ExampleImage}
+              alt="유저의 그림"
+              style={SquareImageStyle}
+            />
+          </div>
+          <div>
+            <h3>2</h3>
+          </div>
+          <div>
+            <h3>3</h3>
+          </div>
+          <div>
+            <h3>4</h3>
+          </div>
+          <div>
+            <h3>5</h3>
+          </div>
+        </Slider>
       </div>
     </section>
   );

--- a/app/_components/main/Carousel.tsx
+++ b/app/_components/main/Carousel.tsx
@@ -4,34 +4,43 @@ import Image from "next/image";
 import React from "react";
 import { SquareImageStyle } from "@/app/_styles/imageStyles";
 import { Posts } from "@/app/_types/detail1/posts";
-import ExampleImage from "@/public/image/example.jpg";
 
 import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
-const Carousel = ({ data }: { data: Posts[] }) => {
-  // /** lkies로부터 가장 많이 작성한 유저 3명 뽑아내기 */
-  // const userCounts: { [email: string]: number } = {};
-  // data?.forEach((post) => {
-  //   if (!post.painter_email) return;
-  //   if (post.painter_email in userCounts) {
-  //     userCounts[post.painter_email]++;
-  //   } else {
-  //     userCounts[post.painter_email] = 1;
-  //   }
-  // });
+import type { Likes } from "@/app/_types/likes";
 
-  // const sortedUsers = Object.entries(userCounts)
-  //   .map(([email, postCount]) => ({ email, postCount }))
-  //   .sort((a, b) => b.postCount - a.postCount)
-  //   .slice(0, 3);
+const Carousel = ({
+  postsData,
+  likesData,
+}: {
+  postsData: Posts[];
+  likesData: Likes[];
+}) => {
+  /** likes로부터 가장 많이 언급된 게시글 뽑아내기 */
+  const userCounts: { [drawingId: string]: number } = {};
+  likesData?.forEach((post) => {
+    if (!post.drawing_id) return;
+    if (post.drawing_id in userCounts) {
+      userCounts[post.drawing_id]++;
+    } else {
+      userCounts[post.drawing_id] = 1;
+    }
+  });
 
-  // const bestUserEmails = sortedUsers.map((user) => user.email);
-  // const bestUsersInfo = usersData.filter((user) =>
-  //   bestUserEmails.includes(user.email)
-  // );
+  const sortedPosts = Object.entries(userCounts)
+    .map(([drawing_id, postCount]) => ({ drawing_id, postCount }))
+    .sort((a, b) => b.postCount - a.postCount)
+    .slice(0, 5);
 
+  /** like를 가장 많이 받은 bestPosts 그리고 각 post의 상세 정보 */
+  const bestPosts = sortedPosts.map((post) => Number(post.drawing_id));
+  const filteredData = postsData.filter((post) =>
+    bestPosts.includes(Number(post.drawing_id))
+  );
+
+  /** 캐러셀 설정 */
   const settings = {
     dots: true,
     infinite: true,
@@ -45,25 +54,17 @@ const Carousel = ({ data }: { data: Posts[] }) => {
       <div className="flex flex-col gap-2 w-[1000px]">
         <h1 className="text-large font-bold">👑베스트 드로잉</h1>
         <Slider {...settings}>
-          <div>
-            <Image
-              src={ExampleImage}
-              alt="유저의 그림"
-              style={SquareImageStyle}
-            />
-          </div>
-          <div>
-            <h3>2</h3>
-          </div>
-          <div>
-            <h3>3</h3>
-          </div>
-          <div>
-            <h3>4</h3>
-          </div>
-          <div>
-            <h3>5</h3>
-          </div>
+          {filteredData.map((item) => (
+            <div key={item.drawing_id}>
+              <Image
+                src={`https://pmduqgivaolwydqssren.supabase.co/storage/v1/object/public/drawings/${item.drawing_url}`}
+                alt="유저의 그림"
+                style={SquareImageStyle}
+                width={300}
+                height={300}
+              />
+            </div>
+          ))}
         </Slider>
       </div>
     </section>

--- a/app/_components/main/Home.tsx
+++ b/app/_components/main/Home.tsx
@@ -3,21 +3,33 @@ import Carousel from "./Carousel";
 import WeeklyTheme from "./WeeklyTheme";
 import Latest from "./Latest";
 import BestPainter from "./BestPainter";
-import { Posts } from "@/app/_types/detail1/posts";
+
+import type { Posts } from "@/app/_types/detail1/posts";
+import type { Likes } from "@/app/_types/likes";
 
 const Home = async () => {
-  const response = await fetch(
+  const resForPosts = await fetch(
     `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/posts`,
     {
       next: { revalidate: 10 },
       headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! },
     }
   );
-  const postsData: Posts[] = await response.json();
+  const postsData: Posts[] = await resForPosts.json();
+
+  /** likes 테이블에서 모든 데이터 가져오기 */
+  const resForLikes = await fetch(
+    `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/likes`,
+    {
+      next: { revalidate: 10 },
+      headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! },
+    }
+  );
+  const likesData: Likes[] = await resForLikes.json();
 
   return (
     <>
-      <Carousel data={postsData} />
+      <Carousel postsData={postsData} likesData={likesData} />
       <WeeklyTheme />
       <Latest />
       <BestPainter data={postsData} />

--- a/app/_components/main/Latest.tsx
+++ b/app/_components/main/Latest.tsx
@@ -42,6 +42,9 @@ const Latest = () => {
       <div className="w-[1000px] mt-10 flex flex-col gap-2">
         <h1 className="text-large font-bold">✨최신 드로잉</h1>
         <div className="flex flex-wrap justify-center gap-5">
+          {latestPosts.length === 0 && (
+            <div>등록된 드로잉이 아직 없습니다.</div>
+          )}
           {latestPosts.map((item) => (
             <div key={item.drawing_url} onClick={handleOnClickImg}>
               <Link href={`/detail/${item.drawing_id}`}>

--- a/app/_types/likes.ts
+++ b/app/_types/likes.ts
@@ -1,0 +1,4 @@
+export interface Likes {
+  drawing_id: number;
+  drawing_url: string;
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "^2.39.8",
     "@tanstack/react-query": "^5.28.4",
+    "@types/react-slick": "^0.23.13",
     "autoprefixer": "10.4.17",
     "geist": "^1.2.1",
     "next": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,6 +247,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-slick@^0.23.13":
+  version "0.23.13"
+  resolved "https://registry.yarnpkg.com/@types/react-slick/-/react-slick-0.23.13.tgz#037434e73a58063047b121e08565f7185d811f36"
+  integrity sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "18.2.66"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.66.tgz#d2eafc8c4e70939c5432221adb23d32d76bfe451"


### PR DESCRIPTION
 ## 📌 관련 이슈
  closed #16

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해 주세요! -->
- [x] main 페이지 상단 캐러셀 기초 기능 구현 완료
- [x] main 페이지 하단 명예의 전당 기능 구현 완료  
- [ ] 세세한 css는 아직입니다

## ✨ 개발 내용
* 캐러셀 구현했습니다. `yarn`해주셔서 react-slick 라이브러리를 다운받아 주세요.
* supabase/likes 에서 가장 많이 언급된(들어온?) 순서대로 drawings_id를 5개 뽑아내서 해당 게시글의 정보를 불러와 출력했습니다.  자바스크립트 공부 많이 해야겠다고 느꼈습니다. 더 쉬운 방법이 있다면 알려주세요...
```
  /** likes로부터 가장 많이 언급된 게시글 뽑아내기 */
  const userCounts: { [drawingId: string]: number } = {};
  likesData?.forEach((post) => {
    if (!post.drawing_id) return;
    if (post.drawing_id in userCounts) {
      userCounts[post.drawing_id]++;
    } else {
      userCounts[post.drawing_id] = 1;
    }
  });

  const sortedPosts = Object.entries(userCounts)
    .map(([drawing_id, postCount]) => ({ drawing_id, postCount }))
    .sort((a, b) => b.postCount - a.postCount)
    .slice(0, 5);

  /** like를 가장 많이 받은 bestPosts 그리고 각 post의 상세 정보 */
  const bestPosts = sortedPosts.map((post) => Number(post.drawing_id));
  const filteredData = postsData.filter((post) =>
    bestPosts.includes(Number(post.drawing_id))
  );
```

* 명예의전당도 비슷한 방식으로 구현했습니다. posts 테이블에 데이터를 가장 많이 올린 유저의 painter_email을 뽑아내서 users 에서 해당 유저의 정보를 뽑아오는 식으로 했습니다.

## 📸 스크린샷(선택)
![image](https://github.com/sparta-PaletteGround/sparta-PaletteGround/assets/153061626/4c1481d6-a0f2-4978-b719-67192e512e52)
