### PR TITLE
[feat] paint-editor 남은 기능 완료

### DIFF
--- a/app/_components/paintEditor/Editor.tsx
+++ b/app/_components/paintEditor/Editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import theme from "@/app/_constant/theme";
 
 import { Excalidraw, exportToBlob } from "@excalidraw/excalidraw";
@@ -18,6 +18,7 @@ import {
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/app/_utils/supabase/supabase";
 import { useUserInfoStore } from "@/app/_store/authStore";
+import { useRouter } from "next/navigation";
 
 const Editor = () => {
   const [title, setTitle] = useState("");
@@ -26,12 +27,20 @@ const Editor = () => {
 
   const [excalidrawAPI, setExcalidrawAPI] =
     useState<ExcalidrawImperativeAPI | null>(null);
-  const [blobUrl, setBlobUrl] = useState("");
 
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const currentUserInfo = useUserInfoStore();
   const currentUserEmail = currentUserInfo.email;
+
+  /** 로그인 안된 유저가 페이지에 접근 시 */
+  useEffect(() => {
+    if (currentUserInfo.email === null) {
+      alert("로그인 후 이용할 수 있는 서비스입니다.");
+      router.replace("/");
+    }
+  }, [currentUserInfo]);
 
   /** 게시글 등록 mutation */
   const insertMutation = useMutation({
@@ -47,6 +56,7 @@ const Editor = () => {
           throw error;
         }
         console.log(`게시글 등록 성공`, data);
+        return data;
       } catch (error) {
         alert(`게시글 등록에 실패했습니다. 다시 시도하세요.`);
         throw error;
@@ -54,7 +64,7 @@ const Editor = () => {
     },
   });
 
-  /** 등록 버튼 클릭 핸들러 */
+  /** 게시글 등록 버튼 클릭 핸들러 */
   const handleOnClick = async () => {
     if (!title || !description) {
       alert(`제목과 내용을 입력해주세요.`);
@@ -75,7 +85,6 @@ const Editor = () => {
         },
         files: excalidrawAPI.getFiles(),
       });
-      setBlobUrl(window.URL.createObjectURL(blob));
       const file = new File([blob], "name");
       const imgUrl: string | unknown = await uploadImageToStorage(
         file,
@@ -99,6 +108,7 @@ const Editor = () => {
       insertMutation.mutate(newPost, {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ["posts"] });
+          // router.push(`/detail/${id}`);
         },
       });
     } catch (error) {

--- a/app/_components/paintEditor/Editor.tsx
+++ b/app/_components/paintEditor/Editor.tsx
@@ -108,7 +108,7 @@ const Editor = () => {
       insertMutation.mutate(newPost, {
         onSuccess: (updatedPost) => {
           queryClient.invalidateQueries({ queryKey: ["posts"] });
-          router.push(`/detail/${updatedPost.drawing_id}`);
+          router.replace(`/detail/${updatedPost.drawing_id}`);
         },
       });
     } catch (error) {

--- a/app/_components/paintEditor/Editor.tsx
+++ b/app/_components/paintEditor/Editor.tsx
@@ -2,11 +2,15 @@
 
 import React, { useEffect, useState } from "react";
 import theme from "@/app/_constant/theme";
+import initialData from "./initialData";
 
 import { Excalidraw, exportToBlob } from "@excalidraw/excalidraw";
-import initialData from "./initialData";
 import { uploadImageToStorage } from "@/app/_api/uploadToStorage";
 import { ThemeImageStyle } from "@/app/_styles/imageStyles";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/app/_utils/supabase/supabase";
+import { useUserInfoStore } from "@/app/_store/authStore";
+import { useRouter } from "next/navigation";
 
 import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types/types";
 import type { Posts } from "@/app/_types/detail1/posts";
@@ -15,10 +19,6 @@ import {
   SubmitBtn,
   TextAreaStyle,
 } from "@/app/_styles/editorPageStyles";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/app/_utils/supabase/supabase";
-import { useUserInfoStore } from "@/app/_store/authStore";
-import { useRouter } from "next/navigation";
 
 const Editor = () => {
   const [title, setTitle] = useState("");
@@ -55,8 +55,8 @@ const Editor = () => {
           alert(`서버 오류 발생! 잠시 후 다시 시도하세요.`);
           throw error;
         }
-        console.log(`게시글 등록 성공`, data);
-        return data;
+        const updatedPost = data[0] as Posts;
+        return updatedPost;
       } catch (error) {
         alert(`게시글 등록에 실패했습니다. 다시 시도하세요.`);
         throw error;
@@ -106,9 +106,9 @@ const Editor = () => {
         chooseTheme,
       };
       insertMutation.mutate(newPost, {
-        onSuccess: () => {
+        onSuccess: (updatedPost) => {
           queryClient.invalidateQueries({ queryKey: ["posts"] });
-          // router.push(`/detail/${id}`);
+          router.push(`/detail/${updatedPost.drawing_id}`);
         },
       });
     } catch (error) {


### PR DESCRIPTION
 ## 📌 관련 이슈
  closed #14 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해 주세요! -->
- [x] 게시글 등록 후 해당 게시글의 detail페이지로 바로 이동하기
- [x] 로그인한 유저만 페이지에 접근 가능하도록 하기  

## ✨ 개발 내용
* 게시글 등록 후 `detail/${updatedPost.drawing_uid}`로 이동합니다. 뒤로가기 클릭 시 에디터로 이동하지 않도록 `router.replace`로 구현해보았습니다.
```
      const newPost: Posts = {
        title,
        description,
        created_at,
        drawing_url: imgUrl,
        painter_email: currentUserEmail,
        likes: 0,
        chooseTheme,
      };
      insertMutation.mutate(newPost, {
        onSuccess: (updatedPost) => {
          queryClient.invalidateQueries({ queryKey: ["posts"] });
          router.replace(`/detail/${updatedPost.drawing_id}`);
        },
      });
```

* `currentUserInfo`의 상태에 따라 함수를 실행시켜 로그인이 확인되지 않는 경우 처리하도록 했습니다.
```
  /** 로그인 안된 유저가 페이지에 접근 시 */
  useEffect(() => {
    if (currentUserInfo.email === null) {
      alert("로그인 후 이용할 수 있는 서비스입니다.");
      router.replace("/");
    }
  }, [currentUserInfo]);
```