### PR TITLE
[feat] header - 프로필이미지 변경

### DIFF
--- a/app/_api/getUsers.ts
+++ b/app/_api/getUsers.ts
@@ -12,3 +12,15 @@ export const getUsers = async (): Promise<User[]> => {
 
   return data || [];
 };
+
+// 로그인한 유저의 profile 이미지 가져오기
+export const getProfileImg = async (email: string | null) => {
+  const { data: profileImg, error } = await supabase
+    .from("users")
+    .select("profile_img")
+    .eq("email", email);
+  if (error) {
+    throw error;
+  }
+  return profileImg;
+};

--- a/app/_components/detail-1/DrawingsByPainter.tsx
+++ b/app/_components/detail-1/DrawingsByPainter.tsx
@@ -43,7 +43,7 @@ const DrawingsByPainter = ({ post }: OwnProp) => {
       {/* 유저가 그린 그림 3 */}
       <div className="flex flex-col gap-2 min-h-[100px]">
         <p className="text-sm font-semibold">
-          🏆 {painterNickname}의 다른 그림
+          🏆 {painterNickname} 님의 다른 그림
         </p>
         <div className="w-60 min-h-16 flex gap-2 items-center">
           <div className="w-full h-full flex flex-wrap gap-2 ">

--- a/app/_components/layout/header-loggedIn.tsx
+++ b/app/_components/layout/header-loggedIn.tsx
@@ -1,0 +1,67 @@
+import { getProfileImg } from "@/app/_api/getUsers";
+import { useAuthStore, useUserInfoStore } from "@/app/_store/authStore";
+import { supabase } from "@/app/_utils/supabase/supabase";
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+
+const LoggedIn = () => {
+  const { setIsLoggedIn } = useAuthStore();
+  const { setUser, email } = useUserInfoStore();
+
+  /** 현재 로그인한 유저의 프로필 이미지 가져오기 **/
+  const {
+    data: profileImgArray,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ["user", { type: "profileImg" }],
+    queryFn: () => getProfileImg(email),
+    enabled: !!email,
+  });
+
+  if (isPending) {
+    return <div>Loading...</div>;
+  }
+  if (isError) {
+    return <div>Error</div>;
+  }
+  const profileImg = profileImgArray[0].profile_img;
+  console.log("profileImg", profileImg);
+
+  /** 로그인한 유저가 로그아웃 클릭 시 */
+  const handleOnClickLogout = async () => {
+    const { error } = await supabase.auth.signOut();
+
+    if (!error) {
+      alert("로그아웃 되었습니다.");
+      setIsLoggedIn(false);
+      setUser({
+        email: null,
+        nickname: null,
+        profileImage: null,
+        googleName: null,
+        googleProfileImg: null,
+      });
+    }
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <div className="flex items-center mr-10 gap-4">
+        <p className="text-white cursor-pointer" onClick={handleOnClickLogout}>
+          로그아웃
+        </p>
+        <Link href="/mypage">
+          <img
+            src={profileImg}
+            alt="사용자 이미지"
+            className="rounded-3xl w-[50px] h-[50px]"
+          />
+        </Link>
+      </div>
+    </>
+  );
+};
+
+export default LoggedIn;

--- a/app/_components/layout/header-loggedIn.tsx
+++ b/app/_components/layout/header-loggedIn.tsx
@@ -26,7 +26,6 @@ const LoggedIn = () => {
     return <div>Error</div>;
   }
   const profileImg = profileImgArray[0].profile_img;
-  console.log("profileImg", profileImg);
 
   /** 로그인한 유저가 로그아웃 클릭 시 */
   const handleOnClickLogout = async () => {

--- a/app/_components/layout/header.tsx
+++ b/app/_components/layout/header.tsx
@@ -1,30 +1,22 @@
 "use client";
 
-import Image from "next/image";
-import React from "react";
+import { useLoggedIn } from "@/app/_hooks/login/useLoggedIn";
+import { useAuthStore } from "@/app/_store/authStore";
 import Logo from "@/public/image/logo-curve.png";
-import defaultUser from "@/public/image/defaultUser.png";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import LoginModal from "../auth/modals/LoginModal";
 import SignupModal from "../auth/modals/SignupModal";
-import { supabase } from "@/app/_utils/supabase/supabase";
 import { YellowLinkBtn } from "../common/Button";
-import Link from "next/link";
-import { useAuthStore, useUserInfoStore } from "@/app/_store/authStore";
-import { useLoggedIn } from "@/app/_hooks/login/useLoggedIn";
-import { useRouter } from "next/navigation";
+import LoggedIn from "./header-loggedIn";
 
 const HeaderNav = () => {
   const router = useRouter();
-  const {
-    setIsLoggedIn,
-    isLoginOpen,
-    setIsLoginOpen,
-    isSignUpOpen,
-    setIsSignUpOpen,
-  } = useAuthStore();
+  const { isLoginOpen, setIsLoginOpen, isSignUpOpen, setIsSignUpOpen } =
+    useAuthStore();
 
-  /** 로그인한 유저가 있는지 확인 */
-  const { setUser } = useUserInfoStore();
+  /** 로그인 상태인지 확인 */
   const isLoggedIn = useLoggedIn();
 
   /** 로그인, 회원가입 클릭 시 모달창 오픈 */
@@ -34,24 +26,6 @@ const HeaderNav = () => {
 
   const handleOnClickToSignUp = () => {
     setIsSignUpOpen(true);
-  };
-
-  /** 로그인한 유저가 로그아웃 클릭 시 */
-  const handleOnClickLogout = async () => {
-    const { error } = await supabase.auth.signOut();
-
-    if (!error) {
-      alert("로그아웃 되었습니다.");
-      setIsLoggedIn(false);
-      setUser({
-        email: null,
-        nickname: null,
-        profileImage: null,
-        googleName: null,
-        googleProfileImg: null,
-      });
-    }
-    window.location.reload();
   };
 
   /** 로그인 안된 유저가 그림그리기 메뉴 클릭 시 */
@@ -99,22 +73,7 @@ const HeaderNav = () => {
           </div>
         ) : (
           /* 로그인 상태 */
-          <div className="flex items-center mr-10 gap-4">
-            <p
-              className="text-white cursor-pointer"
-              onClick={handleOnClickLogout}
-            >
-              로그아웃
-            </p>
-            <Link href="/mypage">
-              <Image
-                src={defaultUser}
-                alt="사용자 이미지"
-                width="50"
-                height="50"
-              />
-            </Link>
-          </div>
+          <LoggedIn />
         )}
       </div>
       {isLoginOpen && <LoginModal />}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,8 +25,10 @@ export default function RootLayout({
     <html lang="en" className={GeistSans.className}>
       <body className="">
         <div></div>
-        <HeaderNav />
-        <QueryProvider>{children}</QueryProvider>
+        <QueryProvider>
+          <HeaderNav />
+          {children}
+        </QueryProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
 ## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #62 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해 주세요! -->
- [x] header의 프로필 이미지를 현재 로그인한 유저의 프로필 이미지로 업데이트

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
1. 로그인 상태일때의 ‘로그아웃’, ‘프로필 이미지’ 부분을 컴포넌트로 분리함
  - header-loggedIn.tsx (컴포넌트 이름 : LoggedIn)
```ts
// header-loggedIn.tsx

  /** 현재 로그인한 유저의 프로필 이미지 가져오기 **/
  const {
    data: profileImgArray,
    isPending,
    isError,
  } = useQuery({
    queryKey: ["user", { type: "profileImg" }],
    queryFn: () => getProfileImg(email),
    enabled: !!email,
  });

  if (isPending) {
    return <div>Loading...</div>;
  }
  if (isError) {
    return <div>Error</div>;
  }
  const profileImg = profileImgArray[0].profile_img;
```

2. header 내의 LoggedIn 컴포넌트에서 useQuery 사용
-> root `layout`에서 `HeaderNav`를 `QueryProvider` 안쪽으로 위치이동
```tsx
// layout.tsx

        <QueryProvider>
          <HeaderNav />
          {children}
        </QueryProvider>
```

3. url로 이미지 보여주느라 img태그로 바꿈
```tsx
// header-loggedIn.tsx

<img
            src={profileImg}
            alt="사용자 이미지"
            className="rounded-3xl w-[50px] h-[50px]"
          />
```

4. 마이페이지에서 프로필이미지 변경시 헤더의 프로필이미지 queryKey도 함께 무효화
- 마이페이지에서 프로필이미지 변경시 무효화하는 queryKey를 header에서도 `prefix`로 추가함
- zustand에서 가져온 email이 null인 경우를 대비, enabled와 isPending 옵션을 추가

```ts
// header-loggedIn.tsx

  /** 현재 로그인한 유저의 프로필 이미지 가져오기 **/
  const {
    data: profileImgArray,
    isPending,
    isError,
  } = useQuery({
    // queryKey 주목
    queryKey: ["user", { type: "profileImg" }],
    queryFn: () => getProfileImg(email),
    // email이 아직 안들어온 경우 query를 실행하지 말고 기다리라는 옵션
    enabled: !!email,
  });
```

##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기해 주세요! -->
- 헤더 프로필 이미지 업데이트 로직 - useQuery를 쓸수밖에 없었던 이유

1. 처음 생각한 로직 : zustand에서 현재 유저의 profileImg 가져오기
- 문제 : 마이페이지에서 프로필이미지 변경시 변경된 이미지를 zustand로 넘겨주는 로직이 없어서 변경된 이미지가 zustand에 반영되지 않음

2. 두번째 생각한 로직 : currentUser를 supabase.auth에서 가져와 profileImg 사용하기
- 문제 : 프로필 이미지 변경시 authentication에 업데이트되는게 아니라서 auth의 profileImg는 최초 가입시의 이미지밖에 없음

3. 결론 : users 테이블에서 프로필이미지 가져오기 
- 로그인한 유저의 email을 users 테이블에서 찾고, 해당 profileImg를 가져와 보여주기

## 📸 스크린샷(선택)
<img width="175" alt="스크린샷 2024-03-24 오전 12 51 23" src="https://github.com/sparta-PaletteGround/sparta-PaletteGround/assets/148458439/96169f8c-8405-4e3c-b936-55b8de21464c">

