### PR TITLE
[fix] - gallery 페이지 drawingsList 데이터 불러오기 오류 수정

### DIFF
--- a/app/_components/drawing-gallery/GalleryHome.tsx
+++ b/app/_components/drawing-gallery/GalleryHome.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import DrawingsList from "./DrawingsList";
 import PainterInfo from "./PainterInfo";
 import { useParams } from "next/navigation";
@@ -14,7 +14,7 @@ const GalleryHome = () => {
 
   /** 선택한 유저의 user 데이터 불러오기 */
   const { data: userData, isLoading: loadingUser } = useQuery({
-    queryKey: ["user"],
+    queryKey: ["user", painterId],
     queryFn: async () => {
       const data = await getPainter(painterId);
       return data;
@@ -22,8 +22,12 @@ const GalleryHome = () => {
   });
 
   /** 해당 유저의 drawing 데이터 불러오기 */
-  const { data: drawingData, isLoading: loadingDrawings } = useQuery({
-    queryKey: ["drawings"],
+  const {
+    data: drawingData,
+    isLoading: loadingDrawings,
+    refetch,
+  } = useQuery({
+    queryKey: ["drawings", painterId],
     queryFn: async () => {
       if (!userData) return [];
       const data = await getDrawings(userData?.email);
@@ -31,6 +35,12 @@ const GalleryHome = () => {
     },
     enabled: !!userData,
   });
+
+  useEffect(() => {
+    if (!loadingUser && !loadingDrawings) {
+      refetch();
+    }
+  }, [painterId, loadingUser, loadingDrawings, refetch]);
 
   if (loadingUser || loadingDrawings) return <div>데이터 로드 중</div>;
   if (!userData || !drawingData)

--- a/app/_components/main/BestPainter.tsx
+++ b/app/_components/main/BestPainter.tsx
@@ -1,20 +1,35 @@
-import Image from "next/image";
-import React from "react";
-import { BestPainterCard } from "@/app/_styles/bestPainterStyles";
-import { Posts } from "@/app/_types/detail1/posts";
-import { User } from "@/app/_types/myPageType";
-import Link from "next/link";
+"use client";
 
-const BestPainter = async ({ data }: { data: Posts[] }) => {
+import React from "react";
+import Link from "next/link";
+import { BestPainterCard } from "@/app/_styles/bestPainterStyles";
+import { useQuery } from "@tanstack/react-query";
+import { getUsers } from "@/app/_api/getUsers";
+
+import type { Posts } from "@/app/_types/detail1/posts";
+import type { User } from "@/app/_types/myPageType";
+
+const BestPainter = ({ data }: { data: Posts[] }) => {
   /** users 테이블에서 모든 데이터 가져오기 */
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/users`,
-    {
-      next: { revalidate: 10 },
-      headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! },
-    }
-  );
-  const usersData: User[] = await response.json();
+  const {
+    data: usersData,
+    isLoading,
+    isError,
+  } = useQuery<User[], Error>({
+    queryKey: ["users"],
+    queryFn: async () => {
+      try {
+        const postData = await getUsers();
+        return postData;
+      } catch (error) {
+        return [];
+      }
+    },
+  });
+
+  if (isLoading) return <div>데이터 로드 중...</div>;
+  if (isError) return <div>데이터 로드 실패</div>;
+  if (!usersData) return;
 
   /** posts로부터 가장 많이 작성한 유저 3명 뽑아내기 */
   const userCounts: { [email: string]: number } = {};


### PR DESCRIPTION
 ## 📌 관련 이슈
#64

## ✨ 개발 내용
main/명예의 전당 에서 유저를 클릭했을 때 gallery 페이지로 넘어갈 때 그림 리스트가 제대로 param값에 따라 업데이트 되지 않는 문제가 있었습니다. 처음 클릭했을 때는 해당 유저의 그림이 잘 출력되는데, 뒤로가기 했다가 다른 유저를 클릭하면 여전히 이전 유저의 그림이 출력되고 있었습니다.

useQuery를 2회 이상 호출하면서 관련 문제가 여럿 있었는데, 이 경우도 그 중 하나인 것 같습니다. queryKey 작성하는 부분에 painterId(param값)를 의존성으로 넣어주었더니 해결되었습니다.

```
  /** 선택한 유저의 user 데이터 불러오기 */
  const { data: userData, isLoading: loadingUser } = useQuery({
    queryKey: ["user", painterId],
    queryFn: async () => {
      const data = await getPainter(painterId);
      return data;
    },
  });

  /** 해당 유저의 drawing 데이터 불러오기 */
  const {
    data: drawingData,
    isLoading: loadingDrawings,
    refetch,
  } = useQuery({
    queryKey: ["drawings", painterId],
    queryFn: async () => {
      if (!userData) return [];
      const data = await getDrawings(userData?.email);
      return data;
    },
    enabled: !!userData,
  });

```