### PR TITLE
[fix] - detail페이지에서 유저 프로필 클릭시 gallery페이지로 이동

### DIFF
--- a/app/_components/detail-1/Painter.tsx
+++ b/app/_components/detail-1/Painter.tsx
@@ -7,6 +7,7 @@ import type { PostProps } from "@/app/_types/detail1/posts";
 
 import { countLikesNumber } from "../detail-api/likes-api";
 import Likes from "./Likes";
+import Link from "next/link";
 
 const Painter = ({ post, id }: PostProps) => {
   // 그림 작성자 nickname, profile_img, 그린 그림들 가져오기
@@ -55,14 +56,17 @@ const Painter = ({ post, id }: PostProps) => {
         <div className="w-[260px] min-h-[370px] flex flex-col justify-between bg-PurplePale p-4 rounded-md">
           {/* 프로필 이미지, 닉네임, 별 */}
           <div className=" flex items-center justify-between">
-            <div className="flex gap-2 items-center">
+            <Link
+              href={`/gallery/${painterInfo?.id}`}
+              className="flex gap-2 items-center"
+            >
               <img
                 className="w-10 object-cover rounded-full"
                 src={painterInfo?.profile_img}
                 alt=""
               />
               <p className="text-md font-semibold">{painterInfo?.nickname}</p>
-            </div>
+            </Link>
           </div>
           {/* 날짜, 제목, 설명, 댓글, 좋아요 수*/}
           <div className="flex flex-col my-4 gap-2">


### PR DESCRIPTION
 ## 📌 관련 이슈
  closed #64 

## Task TODOLIST
- [x] detail페이지에서 유저 프로필 클릭 시 해당 유저의 gallery페이지로 이동

## 📸 스크린샷(선택)
![image](https://github.com/sparta-PaletteGround/sparta-PaletteGround/assets/153061626/a7f45ea2-bbf6-48d3-9a2d-9d75d5749789)
