### PR TITLE
[style] - 캐러셀 이미지 비율 조정

### DIFF
--- a/app/_components/main/Carousel.tsx
+++ b/app/_components/main/Carousel.tsx
@@ -69,6 +69,7 @@ const Carousel = ({
                 style={SquareImageStyle}
                 width={250}
                 height={250}
+                className="object-contain p-4 bg-white"
               />
               <div className="flex pt-5 pb-5 font-bold text-large">
                 🎨{item.title}

--- a/app/_components/main/slick/slick.css
+++ b/app/_components/main/slick/slick.css
@@ -19,7 +19,6 @@
 
 .slick-list {
   position: relative;
-
   display: block;
   overflow: hidden;
 
@@ -67,8 +66,7 @@
 
 .slick-slide {
   display: none;
-  float: left;
-
+  float: right;
   height: 100%;
   min-height: 1px;
 }


### PR DESCRIPTION
 ## 📌 관련 이슈
closed #15 

## Task TODOLIST
- [x] 캐러셀 이미지 비율 조정

## ✨ 개발 내용
이미지 자체에 bg color 줬더니 아주 간단히 해결되었습니다!
```
<Image
   src={`https://pmduqgivaolwydqssren.supabase.co/storage/v1/object/public/drawings/${item.drawing_url}`}
   alt="유저의 그림"
   style={SquareImageStyle}
   width={250}
   height={250}
   className="object-contain p-4 bg-white"
/>
```